### PR TITLE
Issue#3

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -26,22 +26,25 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
+    team = Team.friendly.find(params[:team_id])
     if assigned_user == assign.team.owner
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
+    elsif current_user.id != team.owner_id && current_user.id != assigned_user.id
+      '他人は削除できません'
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless current_user.id == @team.owner_id
+      redirect_to root_path, notice: '権限がありません'
+    end
+  end
 
   def create
     @team = Team.new(team_params)


### PR DESCRIPTION
下記機能実装

1. そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる
TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる


2.Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること


Closes #3